### PR TITLE
Add front page notice box for subscribing to newsletter

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,5 +17,6 @@
 //= require sticky
 //= require overlay
 //= require cookie
+//= require newsletter
 //= require notice
 //= require front

--- a/app/assets/javascripts/newsletter.coffee
+++ b/app/assets/javascripts/newsletter.coffee
@@ -1,0 +1,11 @@
+$(document).on 'ready turbolinks:load', ->
+  'use strict'
+
+  $('[data-action="closeNewsletterNotice"]').on 'click', (e) ->
+    noticeEl = $(e.currentTarget).parents('.front-subscribe-newsletter')
+    noticeEl.css 'bottom', '-100%'
+    e.preventDefault()
+
+    setTimeout ->
+      noticeEl.detach()
+    , 500

--- a/app/assets/javascripts/newsletter.coffee
+++ b/app/assets/javascripts/newsletter.coffee
@@ -6,6 +6,13 @@ $(document).on 'ready turbolinks:load', ->
     noticeEl.css 'bottom', '-100%'
     e.preventDefault()
 
+    $.ajax
+      url: '/dismiss-newsletter-subscribe'
+      type: 'PUT'
+      data: {}
+      success: (data) ->
+        return
+
     setTimeout ->
       noticeEl.detach()
     , 500

--- a/app/assets/stylesheets/components/_newsletter.sass
+++ b/app/assets/stylesheets/components/_newsletter.sass
@@ -1,0 +1,9 @@
+.front-subscribe-newsletter
+  background-color: white
+  text-align: center
+
+  @media screen and (min-width: $small)
+    width: 400px
+
+    .content
+      text-align: left

--- a/app/assets/stylesheets/layouts/_fixed-bottom.sass
+++ b/app/assets/stylesheets/layouts/_fixed-bottom.sass
@@ -1,0 +1,24 @@
+.-fixed-bottom
+  position: fixed
+  left: 2rem
+  right: 2rem
+  bottom: 2rem
+  z-index: 999
+  padding: 0
+
+  .close
+    float: left
+    margin-left: 1rem
+    margin-top: 1rem
+
+    .icon
+      width: 2.25rem
+      height: 2.25rem
+
+  .content
+    padding-left: 4rem
+
+  @media screen and (min-width: $small)
+  @media screen and (min-width: $medium)
+    .content
+      padding-left: 3.25rem

--- a/app/assets/stylesheets/layouts/_fixed-bottom.sass
+++ b/app/assets/stylesheets/layouts/_fixed-bottom.sass
@@ -21,4 +21,4 @@
   @media screen and (min-width: $small)
   @media screen and (min-width: $medium)
     .content
-      padding-left: 3.25rem
+      padding-left: 5.25rem

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,6 @@
 class UserSessionsController < ApplicationController
   before_action :require_login, only: [:destroy]
-  skip_before_action :verify_authenticity_token, only: [:accept_cookies]
+  skip_before_action :verify_authenticity_token, only: [:accept_cookies, :dismiss_newsletter_subscribe]
 
   layout 'modal'
 
@@ -32,6 +32,14 @@ class UserSessionsController < ApplicationController
 
   def accept_cookies
     cookies.permanent[:accepts_cookies] = "yes"
+    render plain: 'noted.'
+  end
+
+  def dismiss_newsletter_subscribe
+    if permission_for_cookie?
+      cookies[:newsletter_subscribe_dismissed] = { expires: 1.day }
+    end
+
     render plain: 'noted.'
   end
 end

--- a/app/views/layouts/front.html.haml
+++ b/app/views/layouts/front.html.haml
@@ -34,7 +34,9 @@
       .block.-bt
         = render partial: 'layouts/partials/primary-footer'
 
-      = render partial: 'user_sessions/cookies'
+      = render layout: 'layouts/partials/fixed-bottom' do
+        = render partial: 'user_sessions/cookies-content'
+
       - if permission_for_cookie?
         = render partial: 'user_sessions/delinquent'
 

--- a/app/views/layouts/front.html.haml
+++ b/app/views/layouts/front.html.haml
@@ -35,6 +35,7 @@
         = render partial: 'layouts/partials/primary-footer'
 
       = render layout: 'layouts/partials/fixed-bottom' do
+        = render partial: 'newsletter/front-subscribe-newsletter'
         = render partial: 'user_sessions/cookies-content'
 
       - if permission_for_cookie?

--- a/app/views/layouts/partials/_fixed-bottom.html.haml
+++ b/app/views/layouts/partials/_fixed-bottom.html.haml
@@ -1,0 +1,2 @@
+.-fixed-bottom
+  = yield

--- a/app/views/newsletter/_front-subscribe-newsletter.html.haml
+++ b/app/views/newsletter/_front-subscribe-newsletter.html.haml
@@ -1,10 +1,11 @@
-.front-subscribe-newsletter
-  %nav.close
-    %a.icon{'data-action': 'closeNewsletterNotice'}
-      %svg{height: "242px", version: "1.1", viewbox: "0 0 242 242", width: "242px", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
-        %rect{fill: "#000000", height: "20", transform: "translate(121.208153, 121.208153) rotate(45.000000) translate(-121.208153, -121.208153) ", width: "320", x: "-38.7918472", y: "111.208153"}
-        %rect{fill: "#000000", height: "20", transform: "translate(121.000000, 121.000000) rotate(-45.000000) translate(-121.000000, -121.000000) ", width: "320", x: "-39", y: "111"}
+- if !logged_in? && !newsletter_subscribe_dismissed?
+  .front-subscribe-newsletter
+    %nav.close
+      %a.icon{'data-action': 'closeNewsletterNotice'}
+        %svg{height: "242px", version: "1.1", viewbox: "0 0 242 242", width: "242px", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
+          %rect{fill: "#000000", height: "20", transform: "translate(121.208153, 121.208153) rotate(45.000000) translate(-121.208153, -121.208153) ", width: "320", x: "-38.7918472", y: "111.208153"}
+          %rect{fill: "#000000", height: "20", transform: "translate(121.000000, 121.000000) rotate(-45.000000) translate(-121.000000, -121.000000) ", width: "320", x: "-39", y: "111"}
 
-  .content.block.-p1
-    .p.-t4
-      Sign up for our free email newsletter. Get our weekly headlines and more, each Wednesday, in your inbox.
+    .content.block.-p1
+      .p.-t4
+        Sign up for our free email newsletter. Get our weekly headlines and more, each Wednesday, in your inbox.

--- a/app/views/newsletter/_front-subscribe-newsletter.html.haml
+++ b/app/views/newsletter/_front-subscribe-newsletter.html.haml
@@ -1,6 +1,6 @@
 .front-subscribe-newsletter
   %nav.close
-    %a.icon{'data-action': ''}
+    %a.icon{'data-action': 'closeNewsletterNotice'}
       %svg{height: "242px", version: "1.1", viewbox: "0 0 242 242", width: "242px", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
         %rect{fill: "#000000", height: "20", transform: "translate(121.208153, 121.208153) rotate(45.000000) translate(-121.208153, -121.208153) ", width: "320", x: "-38.7918472", y: "111.208153"}
         %rect{fill: "#000000", height: "20", transform: "translate(121.000000, 121.000000) rotate(-45.000000) translate(-121.000000, -121.000000) ", width: "320", x: "-39", y: "111"}

--- a/app/views/newsletter/_front-subscribe-newsletter.html.haml
+++ b/app/views/newsletter/_front-subscribe-newsletter.html.haml
@@ -1,0 +1,10 @@
+.front-subscribe-newsletter
+  %nav.close
+    %a.icon{'data-action': ''}
+      %svg{height: "242px", version: "1.1", viewbox: "0 0 242 242", width: "242px", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
+        %rect{fill: "#000000", height: "20", transform: "translate(121.208153, 121.208153) rotate(45.000000) translate(-121.208153, -121.208153) ", width: "320", x: "-38.7918472", y: "111.208153"}
+        %rect{fill: "#000000", height: "20", transform: "translate(121.000000, 121.000000) rotate(-45.000000) translate(-121.000000, -121.000000) ", width: "320", x: "-39", y: "111"}
+
+  .content.block.-p1
+    .p.-t4
+      Sign up for our free email newsletter. Get our weekly headlines and more, each Wednesday, in your inbox.

--- a/app/views/user_sessions/_cookies-content.html.haml
+++ b/app/views/user_sessions/_cookies-content.html.haml
@@ -1,0 +1,14 @@
+- if !permission_for_cookie?
+  .notice.block.-bg-black
+    %nav.close
+      %a.icon{'data-action': 'acceptCookies'}
+        %svg{height: "242px", version: "1.1", viewbox: "0 0 242 242", width: "242px", xmlns: "http://www.w3.org/2000/svg", "xmlns:xlink" => "http://www.w3.org/1999/xlink"}
+          %rect{fill: "#fafafa", height: "20", transform: "translate(121.208153, 121.208153) rotate(45.000000) translate(-121.208153, -121.208153) ", width: "320", x: "-38.7918472", y: "111.208153"}
+          %rect{fill: "#fafafa", height: "20", transform: "translate(121.000000, 121.000000) rotate(-45.000000) translate(-121.000000, -121.000000) ", width: "320", x: "-39", y: "111"}
+
+    .content.block.-p1
+      .p.-centered.-t4
+        :markdown
+          We use first-party cookies to allow visitors to log in to our website and read our articles.
+
+        .block.-my1 #{ link_to "I understand", :accept_cookies, 'data-action': 'acceptCookies', class: 'button -white' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
   get 'login' => 'user_sessions#new', as: :login
   get 'logout' => 'user_sessions#destroy', as: :logout
   put 'accept' => 'user_sessions#accept_cookies', as: :accept_cookies
+  put 'dismiss-newsletter-subscribe' => 'user_sessions#dismiss_newsletter_subscribe'
 
   # user migration
 


### PR DESCRIPTION
@brianflanagan I was asked to add a floating dismissible notice for people to subscribe to the newsletter to the front page similar to https://thecurrentla.com/. This PR is sort of my proposal for you to review on how to add it.

Basically, I added a new layout partial for a container element that's fixed to the bottom. I then made a copy of the cookie notice because the existing one is used elsewhere. I put this cookie notice copy and a new newsletter subscribe box to the fixed-bottom container.

I also added a new cookie to make the subscribe box appear only once every 24 hours if the user is not logged in.

I still have to add the actual subscription form to the box, but I just wanted to see what you think first.